### PR TITLE
fix method getVenue

### DIFF
--- a/foursquareVenues.js
+++ b/foursquareVenues.js
@@ -171,7 +171,8 @@
       getVenue: function(params, callback) {
         var urlString;
         urlString = "https://api.foursquare.com/v2/venues/";
-        urlString += params.venue_id != null;
+        urlString += params.venue_id;
+        urlString += "?v=" + date;
         if (client_id != null) {
           urlString += "&client_id=" + client_id;
         }


### PR DESCRIPTION
method getVenue build wrong urlString

https://api.foursquare.com/v2/venues/true&client_id=MY_CLIENT_ID&client_secret=MY_SECRET_ID&v=20130110

When viewing the source code, I found the following lines (line numbers: 174-180)
urlString += params.venue_id != null;
if (client_id != null) {
urlString += "&client_id=" + client_id;
}
if (client_secret != null) {
urlString += "&client_secret=" + client_secret;
}
I know how to fix this error, but on deploy it will appear again

Please fix this error
P.s. sorry for my bad english :)
