### PR TITLE
CoffeeScript is a devDependency, not a runtime dependency

### DIFF
--- a/foursquareVenues.coffee
+++ b/foursquareVenues.coffee
@@ -1,4 +1,3 @@
-require 'coffee-script'
 request = require 'request'
 querystring = require 'querystring'
 

--- a/foursquareVenues.js
+++ b/foursquareVenues.js
@@ -2,8 +2,6 @@
 (function() {
   var handleRes, querystring, request;
 
-  require('coffee-script');
-
   request = require('request');
 
   querystring = require('querystring');

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
   "author": "Yamil Asusta (elbuo8)",
   "license": "MIT",
   "dependencies": {
-    "request": "~2.40.0",
+    "request": "~2.40.0"
+  },
+  "devDependencies": {
     "coffee-script": "~1.3.3"
   }
 }


### PR DESCRIPTION
Hello, you don't need to `require "coffeescript"` in each file to use coffeescript. Leaving it there affects other coffeescript files because you're using an out of date version, so if I use your library and then want to `require("foo.coffee")` elsewhere in the project, then it will use your older version, leading to really, really strange bugs.

This PR fixes the issue.